### PR TITLE
Fix warning about setting RectTransform's parent

### DIFF
--- a/Runtime/Folder.cs
+++ b/Runtime/Folder.cs
@@ -192,7 +192,7 @@ namespace UnityHierarchyFolders.Runtime
                 if (child.parent == this.transform)
                 {
                     child.name = $"{this.name}/{child.name}";
-                    child.parent = this.transform.parent;
+                    child.SetParent(this.transform.parent, true);
                     child.SetSiblingIndex(++index);
                 }
             }


### PR DESCRIPTION
Unity complains about setting a GameObject's parent directly if the GO has a RectTransform instead of normal Transform.
Using SetParent() the warning is gone while keeping the behaviour the same.