### PR TITLE
Allow choosing between different stripping modes

### DIFF
--- a/Editor/FolderEditorUtils.cs
+++ b/Editor/FolderEditorUtils.cs
@@ -9,7 +9,7 @@ namespace UnityHierarchyFolders.Editor
 {
     public static class FolderEditorUtils
     {
-        private const string _actionName = "Create Heirarchy Folder %#&N";
+        private const string _actionName = "Create Hierarchy Folder %#&N";
 
         /// <summary>Add new folder "prefab".</summary>
         /// <param name="command">Menu command information.</param>

--- a/Editor/FolderEditorUtils.cs
+++ b/Editor/FolderEditorUtils.cs
@@ -34,7 +34,7 @@ namespace UnityHierarchyFolders.Editor
 
             foreach (var folder in Object.FindObjectsOfType<Folder>())
             {
-                folder.Flatten(strippingMode);
+                folder.Flatten(strippingMode, StripSettings.CapitalizeName);
             }
         }
     }

--- a/Editor/FolderEditorUtils.cs
+++ b/Editor/FolderEditorUtils.cs
@@ -30,9 +30,11 @@ namespace UnityHierarchyFolders.Editor
 
         public void OnProcessScene(Scene scene, BuildReport report)
         {
+            var strippingMode = report == null ? StripSettings.PlayMode : StripSettings.Build;
+
             foreach (var folder in Object.FindObjectsOfType<Folder>())
             {
-                folder.Flatten();
+                folder.Flatten(strippingMode);
             }
         }
     }

--- a/Editor/SettingsDrawer.cs
+++ b/Editor/SettingsDrawer.cs
@@ -13,22 +13,24 @@
         [SettingsProvider]
         public static SettingsProvider CreateSettingsProvider()
         {
-            // First parameter is the path in the Settings window.
-            // Second parameter is the scope of this setting: it only appears in the Project Settings window.
             var provider = new SettingsProvider("Preferences/Hierarchy Folders", SettingsScope.User)
             {
-                // Create the SettingsProvider and initialize its drawing (IMGUI) function in place:
                 guiHandler = searchContext =>
                 {
                     StripSettings.PlayMode = (StrippingMode) EditorGUILayout.EnumPopup(
                         "Play Mode Stripping Type", StripSettings.PlayMode);
 
+                    if (StripSettings.PlayMode == StrippingMode.ReplaceWithSeparator)
+                    {
+                        StripSettings.CapitalizeName =
+                            EditorGUILayout.Toggle("Capitalize Folder Names", StripSettings.CapitalizeName);
+                    }
+
                     StripSettings.Build = (StrippingMode) EditorGUILayout.EnumPopup(
                         _buildStrippingName, StripSettings.Build, TypeCanBeInBuild, true);
                 },
 
-                // Populate the search keywords to enable smart search filtering and label highlighting:
-                keywords = new HashSet<string>(new[] { "Play", "Mode", "Build", "Stripping", "Type" })
+                keywords = new HashSet<string>(new[] { "Play", "Mode", "Build", "Stripping", "Type", "Capitalize", "Folder", "Names" })
             };
 
             return provider;

--- a/Editor/SettingsDrawer.cs
+++ b/Editor/SettingsDrawer.cs
@@ -37,7 +37,7 @@
         private static bool TypeCanBeInBuild(Enum enumValue)
         {
             var mode = (StrippingMode) enumValue;
-            return mode == StrippingMode.Prepend || mode == StrippingMode.Delete;
+            return mode == StrippingMode.PrependWithFolderName || mode == StrippingMode.Delete;
         }
     }
 }

--- a/Editor/SettingsDrawer.cs
+++ b/Editor/SettingsDrawer.cs
@@ -1,0 +1,43 @@
+﻿namespace UnityHierarchyFolders.Editor
+{
+    using System;
+    using System.Collections.Generic;
+    using Runtime;
+    using UnityEditor;
+    using UnityEngine;
+
+    internal static class SettingsDrawer
+    {
+        private static readonly GUIContent _buildStrippingName = new GUIContent("Build Stripping Type");
+
+        [SettingsProvider]
+        public static SettingsProvider CreateSettingsProvider()
+        {
+            // First parameter is the path in the Settings window.
+            // Second parameter is the scope of this setting: it only appears in the Project Settings window.
+            var provider = new SettingsProvider("Preferences/Hierarchy Folders", SettingsScope.User)
+            {
+                // Create the SettingsProvider and initialize its drawing (IMGUI) function in place:
+                guiHandler = searchContext =>
+                {
+                    StripSettings.PlayMode = (StrippingMode) EditorGUILayout.EnumPopup(
+                        "Play Mode Stripping Type", StripSettings.PlayMode);
+
+                    StripSettings.Build = (StrippingMode) EditorGUILayout.EnumPopup(
+                        _buildStrippingName, StripSettings.Build, TypeCanBeInBuild, true);
+                },
+
+                // Populate the search keywords to enable smart search filtering and label highlighting:
+                keywords = new HashSet<string>(new[] { "Play", "Mode", "Build", "Stripping", "Type" })
+            };
+
+            return provider;
+        }
+
+        private static bool TypeCanBeInBuild(Enum enumValue)
+        {
+            var mode = (StrippingMode) enumValue;
+            return mode == StrippingMode.Prepend || mode == StrippingMode.Delete;
+        }
+    }
+}

--- a/Editor/SettingsDrawer.cs.meta
+++ b/Editor/SettingsDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 023a1385294f41a6a7d8ae3844629a7c
+timeCreated: 1613836312

--- a/Editor/StripSettings.cs
+++ b/Editor/StripSettings.cs
@@ -1,0 +1,56 @@
+﻿namespace UnityHierarchyFolders.Editor
+{
+    using Runtime;
+    using UnityEditor;
+    using UnityEditor.SettingsManagement;
+
+    internal static class StripSettings
+    {
+        private const string PackageName = "com.xsduan.hierarchy-folders";
+
+        private static Settings _instance;
+        private static UserSetting<StrippingMode> _playModeSetting;
+        private static UserSetting<StrippingMode> _buildSetting;
+
+        public static StrippingMode PlayMode
+        {
+            get
+            {
+                if (_playModeSetting == null)
+                {
+                    Initialize();
+                }
+
+                return _playModeSetting.value;
+            }
+
+            set => _playModeSetting.value = value;
+        }
+
+        public static StrippingMode Build
+        {
+            get
+            {
+                if (_buildSetting == null)
+                {
+                    Initialize();
+                }
+
+                return _buildSetting.value;
+            }
+
+            set => _buildSetting.value = value;
+        }
+
+        private static void Initialize()
+        {
+            _instance = new Settings(PackageName);
+
+            _playModeSetting = new UserSetting<StrippingMode>(_instance, nameof(_playModeSetting),
+                StrippingMode.Prepend, SettingsScope.User);
+
+            _buildSetting = new UserSetting<StrippingMode>(_instance, nameof(_buildSetting),
+                StrippingMode.Prepend, SettingsScope.User);
+        }
+    }
+}

--- a/Editor/StripSettings.cs
+++ b/Editor/StripSettings.cs
@@ -11,6 +11,7 @@
         private static Settings _instance;
         private static UserSetting<StrippingMode> _playModeSetting;
         private static UserSetting<StrippingMode> _buildSetting;
+        private static UserSetting<bool> _capitalizeName;
 
         public static StrippingMode PlayMode
         {
@@ -42,6 +43,21 @@
             set => _buildSetting.value = value;
         }
 
+        public static bool CapitalizeName
+        {
+            get
+            {
+                if (_capitalizeName == null)
+                {
+                    Initialize();
+                }
+
+                return _capitalizeName.value;
+            }
+
+            set => _capitalizeName.value = value;
+        }
+
         private static void Initialize()
         {
             _instance = new Settings(PackageName);
@@ -51,6 +67,8 @@
 
             _buildSetting = new UserSetting<StrippingMode>(_instance, nameof(_buildSetting),
                 StrippingMode.PrependWithFolderName, SettingsScope.User);
+
+            _capitalizeName = new UserSetting<bool>(_instance, nameof(_capitalizeName), true, SettingsScope.User);
         }
     }
 }

--- a/Editor/StripSettings.cs
+++ b/Editor/StripSettings.cs
@@ -47,10 +47,10 @@
             _instance = new Settings(PackageName);
 
             _playModeSetting = new UserSetting<StrippingMode>(_instance, nameof(_playModeSetting),
-                StrippingMode.Prepend, SettingsScope.User);
+                StrippingMode.PrependWithFolderName, SettingsScope.User);
 
             _buildSetting = new UserSetting<StrippingMode>(_instance, nameof(_buildSetting),
-                StrippingMode.Prepend, SettingsScope.User);
+                StrippingMode.PrependWithFolderName, SettingsScope.User);
         }
     }
 }

--- a/Editor/StripSettings.cs.meta
+++ b/Editor/StripSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 56180820a6f84c2b8654c24c9dddb507
+timeCreated: 1613843945

--- a/Editor/UnityHierarchyFolders.Editor.asmdef
+++ b/Editor/UnityHierarchyFolders.Editor.asmdef
@@ -1,9 +1,10 @@
 {
     "name": "UnityHierarchyFolders.Editor",
+    "rootNamespace": "",
     "references": [
-        "UnityHierarchyFolders.Runtime"
+        "UnityHierarchyFolders.Runtime",
+        "Unity.Settings.Editor"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,5 +13,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ To install OpenUPM, please see the [documentation][2].
 
 [2]: https://openupm.com/docs/
 
+## Stripping Modes
+
+You can choose how exactly the folder will be removed from the hierarchy in **Preferences -> HierarchyFolders**.
+
+The following stripping modes are available:
+
+- **Prepend With Folder Name** - The folder will be removed, and all child objects will be prepended with the folder name (e.g. childObject => Folder/childObject). This is the default behaviour.
+- **Delete** - The folder will be removed, and names of child objects will not change.
+- **Do Nothing** *(available only for Play Mode)* - The folder will not be removed, the hierarchy will not change in play mode. Use this mode if you don't need extra performance in Editor.
+- **Replace With Separator** *(available only for Play Mode)* - The hierarchy will flatten, and the folder will be replaced with a separator (e.g. "--- FOLDER ---"). Useful if you need extra performance in Editor but still want to see what folder game objects belong to.
+
 ## Possible FAQs
 
 ### Why folders in the first place?

--- a/Runtime/Folder.cs
+++ b/Runtime/Folder.cs
@@ -183,12 +183,25 @@ namespace UnityHierarchyFolders.Runtime
         }
 
         /// <summary>Takes direct children and links them to the parent transform or global.</summary>
+        /// <param name="strippingMode">Stripping mode to apply.</param>
+        /// <param name="capitalizeFolderName">
+        /// Whether to capitalize the folder name when replacing it with a separator.
+        /// Applies only if <paramref name="strippingMode"/> is <see cref="StrippingMode.ReplaceWithSeparator"/>
+        /// </param>
         public void Flatten(StrippingMode strippingMode, bool capitalizeFolderName)
         {
             if (strippingMode == StrippingMode.DoNothing)
                 return;
 
+            MoveChildrenOut(strippingMode);
+
+            HandleSelf(strippingMode, capitalizeFolderName);
+        }
+
+        private void MoveChildrenOut(StrippingMode strippingMode)
+        {
             int index = this.transform.GetSiblingIndex(); // keep components in logical order
+
             foreach (var child in GetComponentsInChildren<Transform>(includeInactive: true))
             {
                 // gather only first-level children
@@ -203,19 +216,16 @@ namespace UnityHierarchyFolders.Runtime
                 child.SetParent(this.transform.parent, true);
                 child.SetSiblingIndex(++index);
             }
+        }
 
+        private void HandleSelf(StrippingMode strippingMode, bool capitalizeFolderName)
+        {
             if (strippingMode == StrippingMode.ReplaceWithSeparator)
             {
                 name = $"--- {(capitalizeFolderName ? name.ToUpper() : name)} ---";
+                return;
             }
-            else
-            {
-                DestroySelf();
-            }
-        }
 
-        private void DestroySelf()
-        {
             if (Application.isPlaying)
             {
                 Destroy(this.gameObject);

--- a/Runtime/Folder.cs
+++ b/Runtime/Folder.cs
@@ -183,7 +183,7 @@ namespace UnityHierarchyFolders.Runtime
         }
 
         /// <summary>Takes direct children and links them to the parent transform or global.</summary>
-        public void Flatten()
+        public void Flatten(StrippingMode strippingMode)
         {
             // gather first-level children
             int index = this.transform.GetSiblingIndex(); // keep components in logical order

--- a/Runtime/Folder.cs
+++ b/Runtime/Folder.cs
@@ -183,7 +183,7 @@ namespace UnityHierarchyFolders.Runtime
         }
 
         /// <summary>Takes direct children and links them to the parent transform or global.</summary>
-        public void Flatten(StrippingMode strippingMode)
+        public void Flatten(StrippingMode strippingMode, bool capitalizeFolderName)
         {
             if (strippingMode == StrippingMode.DoNothing)
                 return;
@@ -206,7 +206,7 @@ namespace UnityHierarchyFolders.Runtime
 
             if (strippingMode == StrippingMode.ReplaceWithSeparator)
             {
-                name = $"--- {name} ---";
+                name = $"--- {(capitalizeFolderName ? name.ToUpper() : name)} ---";
             }
             else
             {

--- a/Runtime/StrippingMode.cs
+++ b/Runtime/StrippingMode.cs
@@ -1,0 +1,7 @@
+﻿namespace UnityHierarchyFolders.Runtime
+{
+    public enum StrippingMode
+    {
+        Prepend, Delete, None, Separator
+    }
+}

--- a/Runtime/StrippingMode.cs
+++ b/Runtime/StrippingMode.cs
@@ -2,6 +2,6 @@
 {
     public enum StrippingMode
     {
-        Prepend, Delete, None, Separator
+        PrependWithFolderName, Delete, DoNothing, ReplaceWithSeparator
     }
 }

--- a/Runtime/StrippingMode.cs.meta
+++ b/Runtime/StrippingMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3634a380eb0d4432a5396f7cdc085414
+timeCreated: 1613841896

--- a/Runtime/UnityHierarchyFolders.Runtime.asmdef
+++ b/Runtime/UnityHierarchyFolders.Runtime.asmdef
@@ -1,12 +1,14 @@
 {
     "name": "UnityHierarchyFolders.Runtime",
+    "rootNamespace": "",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.xsduan.hierarchy-folders",
   "displayName": "Hierarchy Folders",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "unity": "2018.1",
   "description": "Self-deleting Folder objects for the heirarchy.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.xsduan.hierarchy-folders",
-  "displayName": "Heirarchy Folders",
+  "displayName": "Hierarchy Folders",
   "version": "0.2.1",
   "unity": "2018.1",
   "description": "Self-deleting Folder objects for the heirarchy.",

--- a/package.json
+++ b/package.json
@@ -13,5 +13,7 @@
     "name": "Shane Duan"
   },
   "category": "Unity",
-  "dependencies": {}
+  "dependencies": {
+    "com.unity.settings-manager": "1.0.1"
+  }
 }


### PR DESCRIPTION
At the moment, each child object of a folder is prepended with the folder name. This is nice, but sometimes the user doesn't want GameObject names to change because the names are referenced somewhere, etc. This PR allows to choose between several stripping modes:
- Prepend child objects with the folder name (default, the same behavior the plugin had before, so nothing will change for existing users).
- Just delete the folder, without prepending child objects with the folder name.
- Flatten the hierarchy and make the folder a separator - this still improves the performance of the game but makes it easier to find objects on the scene in play mode.
- Do nothing - for users who don't need an additional performance in the editor.

The user can choose between those options in the Performance window. They will be able to choose different modes for Play Mode and Build: for example, don't flatten hierarchy in Play Mode but strip folders when creating a build.

![image](https://user-images.githubusercontent.com/22909454/108623356-4db2de00-7447-11eb-9d31-6e8baa6f2023.png)

- [x] Made sure that performance impact hasn't changed
- [x] Verified that the plugin works in Unity 2019-2021
- [x] Added new information to README

Since this is a new feature, I bumped the package version to 0.3.0. Please create a new release once the PR is merged for the new version to appear on OpenUPM.