### PR TITLE
Reset folders to local origin

### DIFF
--- a/Runtime/Folder.cs
+++ b/Runtime/Folder.cs
@@ -168,9 +168,9 @@ namespace UnityHierarchyFolders.Runtime
         /// </summary>
         private void Update()
         {
-            this.transform.position = Vector3.zero;
-            this.transform.rotation = Quaternion.identity;
-            this.transform.localScale = new Vector3(1, 1, 1);
+            this.transform.localPosition = Vector3.zero;
+            this.transform.localRotation = Quaternion.identity;
+            this.transform.localScale = Vector3.one;
 
 #if UNITY_EDITOR
             if (!Application.IsPlaying(this.gameObject))


### PR DESCRIPTION
The previous behavior had folders reset to world origin:
- position (0,0,0)
- rotation (0,0,0)

This is undesirable for nested folders, where the hierarchy would come out like this:
- GameObject (15, 4, 7) 
    - Folder (-15, -4, -7) 
        - Prop (15, 4, 7)

For the ability to use folders in a nested context like this the new behavior resets folders to local origin:
- localPosition (0,0,0)
- localRotation (0,0,0)