### PR TITLE
Select the created folder when it is created

### DIFF
--- a/Editor/FolderEditorUtils.cs
+++ b/Editor/FolderEditorUtils.cs
@@ -21,6 +21,7 @@ namespace UnityHierarchyFolders.Editor
 
             GameObjectUtility.SetParentAndAlign(obj, (GameObject)command.context);
             Undo.RegisterCreatedObjectUndo(obj, _actionName);
+            Selection.activeObject = obj;
         }
     }
 


### PR DESCRIPTION
The default behaviour when creating objects in Unity (at least in recent versions) is to automatically select the created object.

This has the added benefit of automatically entering rename mode (at least in 2022.3), which is also expected.

Love the project btw! 😊