### PR TITLE
Unity 6.3 support + rewrite Color picker + various fix

### DIFF
--- a/Editor/Icon Handling/HierarchyFolderIcon.cs
+++ b/Editor/Icon Handling/HierarchyFolderIcon.cs
@@ -157,7 +157,6 @@ namespace UnityHierarchyFolders.Editor
         public static void ForceRepaint()
         {
             InitIfNeeded();
-            _hasProcessedFrame = false;
             EditorApplication.RepaintHierarchyWindow();
         }
 
@@ -222,13 +221,10 @@ namespace UnityHierarchyFolders.Editor
                 _openVariants = _closedVariants = null;
             }
 
-            _hasProcessedFrame = false;
         }
 
         private static void RefreshFolderIcons(int instanceid, Rect selectionrect)
         {
-            if (_hasProcessedFrame) return;
-            _hasProcessedFrame = true;
 
             if (meth_getAllSceneHierarchyWindows == null || prop_sceneHierarchy == null)
                 return;


### PR DESCRIPTION
feat: Unity 6.3 compatibility, safe reflection, 1D palette, reliable repaint

Replace ambiguous reflection with exact lookups

- Methods: GetMethod("...", types: Type.EmptyTypes)

- Properties: GetPropertyExact(type, name, returnType) to avoid AmbiguousMatchException

- Resolve members from instances (sceneHierarchy, treeView, data) in RefreshFolderIcons()

- Stop eager binding of fragile PropertyInfo/MethodInfo; use name + arity at runtime

- Add hard guards in IMGUI path to prevent NRE and GUI clip errors

- try/catch around reflection, early returns


Switch to 1D color palette

- HierarchyFolderIcon.IconColors : Color[]

- pre-tinted variants _openVariants/_closedVariants

- GetIcons(storedIndex, out openTex, out closedTex) maps 0=default, 1..N=colors[i-1]

Update InitIfNeeded()

- cache only GetAllSceneHierarchyWindows() and sceneHierarchy property

- support moved types (UnityEditor.SceneHierarchy or UnityEditor.IMGUI.Controls.SceneHierarchy)

- Add ForceRepaint() and ResetFolderIcons()

- load default folder icons

- rebuild tinted variants on demand

- force hierarchy repaint after changes

Fix FolderEditor

- use actual serialized field "_colorIndex"

- UI is 0-based, storage is 1-based (_colorIndex = popup + 1)

- clamp index and show color preview

- Align Folder.TryGetIconIndex()

- return false if _colorIndex == 0, else index = 1..N expected by GetIcons()

- clamp against HierarchyFolderIcon.IconColors.Length

Cleanup

- remove old 2D palette logic, tuples, and obsolete caches

- remove eager binds for treeView/data/selectedIcon/objectPPTR

- add helpers GetPropertyByName and GetPropertyExact

- Result: no lag or AmbiguousMatchException on Unity 6.3, colored folder icons apply correctly, inspector changes update the hierarchy immediately.